### PR TITLE
Support new tags format

### DIFF
--- a/jekylltoghost.rb
+++ b/jekylltoghost.rb
@@ -103,6 +103,9 @@ module Jekyll
 
 		def process_tags(tags, categories)
 			unique_tags = tags | categories
+			unique_tags.map! do |t|
+				t.chomp(",")
+			end
 			@tags = unique_tags | @tags
 			post_tags = []
 			unique_tags.each do |t|

--- a/jekylltoghost.rb
+++ b/jekylltoghost.rb
@@ -122,7 +122,7 @@ module Jekyll
 			tag_array = []
 			@tags.each do |tag|
 				tag_array.push({
-					"id" => (tag_array.size + 1),
+					"id" => tag_array.size,
 					"name" => tag,
 					"slug" => tag.downcase,
 					"description" => ""

--- a/jekylltoghost.rb
+++ b/jekylltoghost.rb
@@ -110,6 +110,7 @@ module Jekyll
 			unique_tags = tags | categories
 			unique_tags = unique_tags.map do |t|
 				t = t.chomp(",")
+				t = t.downcase
 			end
 			@tags = unique_tags | @tags
 


### PR DESCRIPTION
Jekyll 0.4 stores the post tags in another table.
