### PR TITLE
Update deprecated function, get build to complete

### DIFF
--- a/jekylltoghost.rb
+++ b/jekylltoghost.rb
@@ -53,7 +53,7 @@ module Jekyll
 
 		def generate(site)
 
-			converter = site.getConverterImpl(Jekyll::Converters::Markdown)
+			converter = site.find_converter_instance(Jekyll::Converters::Markdown)
 			ex_posts = []
 			id = 0
 


### PR DESCRIPTION
Still throws a warning, but at least it completes now. Fixes #7
https://github.com/octopress/quote-tag/issues/5
